### PR TITLE
Update CKAN 2.9.9 Dev

### DIFF
--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 ARG CKAN_VERSION=ckan-2.9.9
 
 # Internals, you probably don't need to change these

--- a/ckan-2.9/base/Dockerfile
+++ b/ckan-2.9/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM python:3.9-alpine3.18
 ARG CKAN_VERSION=ckan-2.9.9
 
 # Internals, you probably don't need to change these
@@ -75,8 +75,9 @@ COPY setup/supervisord.conf /etc
 RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     cd ${SRC_DIR}/ckan && \
     cp who.ini ${APP_DIR} && \
-    pip3 install -r requirement-setuptools.txt && \
-    pip3 install --no-binary markdown -r requirements.txt && \
+    # Temp fix PyYaml Cython 3 erors: https://github.com/yaml/pyyaml/issues/724
+    pip3 install --no-binary markdown -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt && \
+    #pip3 install --no-binary markdown -r requirements.txt && \
     # Install CKAN envvars to support loading config from environment variables
     pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \
     # Create and update CKAN config

--- a/ckan-master/base/Dockerfile
+++ b/ckan-master/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.18
 ARG CKAN_VERSION=ckan-2.9.9
 
 # Internals, you probably don't need to change these

--- a/ckan-master/base/Dockerfile
+++ b/ckan-master/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM python:3.9-alpine3.18
 ARG CKAN_VERSION=ckan-2.9.9
 
 # Internals, you probably don't need to change these
@@ -75,8 +75,9 @@ COPY setup/supervisord.conf /etc
 RUN pip3 install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
     cd ${SRC_DIR}/ckan && \
     cp who.ini ${APP_DIR} && \
-    pip3 install -r requirement-setuptools.txt && \
-    pip3 install --no-binary markdown -r requirements.txt && \
+    # Temp fix PyYaml Cython 3 erors: https://github.com/yaml/pyyaml/issues/724
+    pip3 install --no-binary markdown -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt && \
+    #pip3 install --no-binary markdown -r requirements.txt && \
     # Install CKAN envvars to support loading config from environment variables
     pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \
     # Create and update CKAN config

--- a/ckan-master/base/build.log
+++ b/ckan-master/base/build.log
@@ -1,0 +1,592 @@
+#2 [internal] load .dockerignore
+#2 sha256:536d5baeec13c6ad1635fabfc77af84769c7abee3be420be5224578e24593021
+#2 transferring context: 2B 0.1s done
+#2 DONE 0.2s
+
+#1 [internal] load build definition from Dockerfile
+#1 sha256:752419c845bbbb4a675208bcf84d2ac8e1a004755f0f98b58d95b589de5a1b69
+#1 transferring dockerfile: 35B 0.0s done
+#1 DONE 0.2s
+
+#3 [internal] load metadata for docker.io/library/python:3.9-alpine3.18
+#3 sha256:fa04d298730ffbf4b8cd6b556947a6118f7422dde74f31f64c5b67853b2fd152
+#3 ...
+
+#4 [auth] library/python:pull token for registry-1.docker.io
+#4 sha256:91f3a1062f9e62248c49834ce7bb3307a21e1ce4045b71c86c2a9348c32810f2
+#4 DONE 0.0s
+
+#3 [internal] load metadata for docker.io/library/python:3.9-alpine3.18
+#3 sha256:fa04d298730ffbf4b8cd6b556947a6118f7422dde74f31f64c5b67853b2fd152
+#3 DONE 0.8s
+
+#5 [ 1/11] FROM docker.io/library/python:3.9-alpine3.18@sha256:2e94e493d6d5010d739ea473e44ea40f7c6e168bcb78e0c5a48c64f06aafbf5f
+#5 sha256:a0d66cd61464d71df6ab516b92ef05161dc828f971e5a091847e8b33a7b5bd88
+#5 DONE 0.0s
+
+#6 [ 2/11] WORKDIR /srv/app
+#6 sha256:2fce5c52d080d68178bc83fb528810ec30a351c5951455b803dd65525f5b0407
+#6 CACHED
+
+#8 [internal] load build context
+#8 sha256:7d07462794ffaf374614eff6fbb14f3c23f948f84b7a062f9279e3aeb713e880
+#8 transferring context: 201B done
+#8 DONE 0.2s
+
+#15 https://raw.githubusercontent.com/ckan/ckan/ckan-2.9.9/wsgi.py
+#15 sha256:2d6e3a9cd239c4cbb7a3bbd1e7c329e0598f07dff66168f4e661a6c3b91a6a20
+#15 DONE 0.3s
+
+#7 [ 3/11] RUN apk add --no-cache tzdata         git         gettext         postgresql-client         python3         libxml2         libxslt         musl-dev         uwsgi         uwsgi-http         uwsgi-corerouter         uwsgi-python         py3-gevent         uwsgi-gevent         libmagic         curl         sed         patch &&     apk add --no-cache --virtual .build-deps         postgresql-dev         gcc         make         g++         autoconf         automake     	libtool         python3-dev         libxml2-dev         libxslt-dev         linux-headers         openssl-dev         libffi-dev         cargo         geos-dev         proj         proj-util         proj-dev &&     mkdir -p /srv/app/src &&     curl -o /srv/app/src/get-pip.py https://bootstrap.pypa.io/get-pip.py &&     python3 /srv/app/src/get-pip.py &&     pip3 install supervisor &&     mkdir /etc/supervisord.d &&     rm -rf /srv/app/src/get-pip.py
+#7 sha256:ec60143e3d1bfa75a4843c6912830ee905c72fa3b7220820b81efc04a17984a1
+#7 ...
+
+#15 https://raw.githubusercontent.com/ckan/ckan/ckan-2.9.9/wsgi.py
+#15 sha256:2d6e3a9cd239c4cbb7a3bbd1e7c329e0598f07dff66168f4e661a6c3b91a6a20
+#15 CACHED
+
+#7 [ 3/11] RUN apk add --no-cache tzdata         git         gettext         postgresql-client         python3         libxml2         libxslt         musl-dev         uwsgi         uwsgi-http         uwsgi-corerouter         uwsgi-python         py3-gevent         uwsgi-gevent         libmagic         curl         sed         patch &&     apk add --no-cache --virtual .build-deps         postgresql-dev         gcc         make         g++         autoconf         automake     	libtool         python3-dev         libxml2-dev         libxslt-dev         linux-headers         openssl-dev         libffi-dev         cargo         geos-dev         proj         proj-util         proj-dev &&     mkdir -p /srv/app/src &&     curl -o /srv/app/src/get-pip.py https://bootstrap.pypa.io/get-pip.py &&     python3 /srv/app/src/get-pip.py &&     pip3 install supervisor &&     mkdir /etc/supervisord.d &&     rm -rf /srv/app/src/get-pip.py
+#7 sha256:ec60143e3d1bfa75a4843c6912830ee905c72fa3b7220820b81efc04a17984a1
+#7 0.818 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
+#7 0.978 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
+#7 1.261 (1/62) Installing brotli-libs (1.0.9-r14)
+#7 1.276 (2/62) Installing libunistring (1.1-r1)
+#7 1.293 (3/62) Installing libidn2 (2.3.4-r1)
+#7 1.297 (4/62) Installing nghttp2-libs (1.53.0-r0)
+#7 1.302 (5/62) Installing libcurl (8.1.2-r0)
+#7 1.312 (6/62) Installing curl (8.1.2-r0)
+#7 1.322 (7/62) Installing gettext-envsubst (0.21.1-r7)
+#7 1.325 (8/62) Installing libgomp (12.2.1_git20220924-r10)
+#7 1.334 (9/62) Installing gettext-libs (0.21.1-r7)
+#7 1.349 (10/62) Installing libxml2 (2.11.4-r0)
+#7 1.366 (11/62) Installing gettext (0.21.1-r7)
+#7 1.388 (12/62) Installing pcre2 (10.42-r1)
+#7 1.397 (13/62) Installing git (2.40.1-r0)
+#7 1.467 (14/62) Installing libmagic (5.44-r4)
+#7 1.494 (15/62) Installing libgpg-error (1.47-r1)
+#7 1.498 (16/62) Installing libgcrypt (1.10.2-r1)
+#7 1.513 (17/62) Installing libxslt (1.1.38-r0)
+#7 1.523 (18/62) Installing musl-dev (1.2.4-r0)
+#7 1.600 (19/62) Installing patch (2.7.6-r10)
+#7 1.605 (20/62) Installing postgresql-common (1.2-r0)
+#7 1.607 Executing postgresql-common-1.2-r0.pre-install
+#7 1.705 (21/62) Installing lz4-libs (1.9.4-r4)
+#7 1.709 (22/62) Installing libpq (15.3-r0)
+#7 1.717 (23/62) Installing zstd-libs (1.5.5-r4)
+#7 1.733 (24/62) Installing postgresql15-client (15.3-r0)
+#7 1.777 (25/62) Installing libgcc (12.2.1_git20220924-r10)
+#7 1.780 (26/62) Installing libstdc++ (12.2.1_git20220924-r10)
+#7 1.798 (27/62) Installing mpdecimal (2.5.1-r2)
+#7 1.803 (28/62) Installing python3 (3.11.4-r0)
+#7 2.015 (29/62) Installing python3-pycache-pyc0 (3.11.4-r0)
+#7 2.149 (30/62) Installing pyc (0.1-r0)
+#7 2.152 (31/62) Installing py3-cparser-pyc (2.21-r2)
+#7 2.161 (32/62) Installing py3-greenlet (2.0.2-r2)
+#7 2.170 (33/62) Installing py3-greenlet-pyc (2.0.2-r2)
+#7 2.179 (34/62) Installing py3-parsing (3.0.9-r2)
+#7 2.192 (35/62) Installing py3-parsing-pyc (3.0.9-r2)
+#7 2.202 (36/62) Installing py3-packaging (23.1-r1)
+#7 2.208 (37/62) Installing py3-packaging-pyc (23.1-r1)
+#7 2.212 (38/62) Installing py3-setuptools (67.7.2-r0)
+#7 2.250 (39/62) Installing py3-setuptools-pyc (67.7.2-r0)
+#7 2.322 (40/62) Installing py3-zope-event (4.6-r1)
+#7 2.332 (41/62) Installing py3-zope-event-pyc (4.6-r1)
+#7 2.337 (42/62) Installing py3-zope-interface (6.0-r0)
+#7 2.356 (43/62) Installing py3-zope-interface-pyc (6.0-r0)
+#7 2.399 (44/62) Installing py3-gevent-pyc (22.10.2-r4)
+#7 2.427 (45/62) Installing py3-cffi-pyc (1.15.1-r3)
+#7 2.436 (46/62) Installing python3-pyc (3.11.4-r0)
+#7 2.449 (47/62) Installing py3-cparser (2.21-r2)
+#7 2.456 (48/62) Installing py3-cffi (1.15.1-r3)
+#7 2.466 (49/62) Installing c-ares (1.19.1-r0)
+#7 2.468 (50/62) Installing libev (4.33-r1)
+#7 2.471 (51/62) Installing libuv (1.44.2-r2)
+#7 2.480 (52/62) Installing py3-gevent (22.10.2-r4)
+#7 2.514 (53/62) Installing sed (4.9-r2)
+#7 2.521 (54/62) Installing mailcap (2.1.54-r0)
+#7 2.525 (55/62) Installing libcap2 (2.69-r0)
+#7 2.528 (56/62) Installing jansson (2.14-r3)
+#7 2.531 (57/62) Installing pcre (8.45-r3)
+#7 2.539 (58/62) Installing uwsgi (2.0.21-r3)
+#7 2.548 Executing uwsgi-2.0.21-r3.pre-install
+#7 2.932 (59/62) Installing uwsgi-corerouter (2.0.21-r3)
+#7 2.934 (60/62) Installing uwsgi-gevent3 (2.0.21-r3)
+#7 2.936 (61/62) Installing uwsgi-http (2.0.21-r3)
+#7 2.939 (62/62) Installing uwsgi-python3 (2.0.21-r3)
+#7 2.944 Executing busybox-1.36.1-r0.trigger
+#7 2.948 Executing postgresql-common-1.2-r0.trigger
+#7 2.951 * Setting postgresql15 as the default version
+#7 3.068 WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/main: No such file or directory
+#7 3.068 WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/community: No such file or directory
+#7 3.072 sh: out of range
+#7 3.075 OK: 115 MiB in 100 packages
+#7 3.142 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
+#7 3.234 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
+#7 3.467 (1/72) Upgrading libcrypto3 (3.1.1-r1 -> 3.1.1-r2)
+#7 3.507 (2/72) Upgrading libssl3 (3.1.1-r1 -> 3.1.1-r2)
+#7 3.517 (3/72) Installing pkgconf (1.9.5-r0)
+#7 3.520 (4/72) Installing openssl-dev (3.1.1-r2)
+#7 3.542 (5/72) Installing libpq-dev (15.3-r0)
+#7 3.558 (6/72) Installing libecpg (15.3-r0)
+#7 3.562 (7/72) Installing libecpg-dev (15.3-r0)
+#7 3.574 (8/72) Installing llvm14-libs (14.0.6-r14)
+#7 4.541 (9/72) Installing clang14-libs (14.0.6-r7)
+#7 4.930 (10/72) Installing binutils (2.40-r7)
+#7 4.993 (11/72) Installing libatomic (12.2.1_git20220924-r10)
+#7 4.995 (12/72) Installing gmp (6.2.1-r3)
+#7 5.002 (13/72) Installing isl26 (0.26-r1)
+#7 5.022 (14/72) Installing mpfr4 (4.2.0-r3)
+#7 5.031 (15/72) Installing mpc1 (1.3.1-r1)
+#7 5.034 (16/72) Installing gcc (12.2.1_git20220924-r10)
+#7 6.333 (17/72) Installing libstdc++-dev (12.2.1_git20220924-r10)
+#7 6.889 (18/72) Installing clang14-libclang (14.0.6-r7)
+#7 7.120 (19/72) Installing clang14 (14.0.6-r7)
+#7 7.209 (20/72) Installing icu-data-en (73.2-r2)
+#7 7.234 Executing icu-data-en-73.2-r2.post-install
+#7 7.236 *
+#7 7.236 * If you need ICU with non-English locales and legacy charset support, install
+#7 7.236 * package icu-data-full.
+#7 7.236 *
+#7 7.236 (21/72) Installing icu-libs (73.2-r2)
+#7 7.273 (22/72) Installing icu (73.2-r2)
+#7 7.284 (23/72) Installing icu-dev (73.2-r2)
+#7 7.334 (24/72) Installing llvm14 (14.0.6-r14)
+#7 7.810 (25/72) Installing lz4-dev (1.9.4-r4)
+#7 7.814 (26/72) Installing zstd (1.5.5-r4)
+#7 7.824 (27/72) Installing zstd-dev (1.5.5-r4)
+#7 7.828 (28/72) Installing postgresql15-dev (15.3-r0)
+#7 7.962 (29/72) Installing make (4.4.1-r1)
+#7 7.967 (30/72) Installing libc-dev (0.7.2-r5)
+#7 7.969 (31/72) Installing g++ (12.2.1_git20220924-r10)
+#7 8.316 (32/72) Installing m4 (1.4.19-r3)
+#7 8.323 (33/72) Installing perl (5.36.1-r2)
+#7 8.840 (34/72) Installing autoconf (2.71-r2)
+#7 8.866 (35/72) Installing automake (1.16.5-r2)
+#7 8.893 (36/72) Installing libltdl (2.4.7-r2)
+#7 8.896 (37/72) Installing libtool (2.4.7-r2)
+#7 8.923 (38/72) Installing python3-dev (3.11.4-r0)
+#7 9.372 (39/72) Installing zlib-dev (1.2.13-r1)
+#7 9.378 (40/72) Installing xz (5.4.3-r0)
+#7 9.383 (41/72) Installing xz-dev (5.4.3-r0)
+#7 9.387 (42/72) Installing libxml2-utils (2.11.4-r0)
+#7 9.390 (43/72) Installing libxml2-dev (2.11.4-r0)
+#7 9.397 (44/72) Installing libxslt-dev (1.1.38-r0)
+#7 9.402 (45/72) Installing linux-headers (6.3-r0)
+#7 9.508 (46/72) Installing libffi-dev (3.4.4-r2)
+#7 9.512 (47/72) Installing llvm16-libs (16.0.6-r1)
+#7 10.80 (48/72) Installing rust (1.70.0-r0)
+#7 15.89 (49/72) Installing cargo (1.70.0-r0)
+#7 16.02 (50/72) Installing geos (3.11.2-r0)
+#7 16.04 (51/72) Installing geos-dev (3.11.2-r0)
+#7 16.09 (52/72) Installing libjpeg-turbo (2.1.5.1-r3)
+#7 16.10 (53/72) Installing libwebp (1.3.1-r0)
+#7 16.11 (54/72) Installing tiff (4.5.1-r0)
+#7 16.12 (55/72) Installing proj (9.2.1-r0)
+#7 16.19 (56/72) Installing proj-util (9.2.1-r0)
+#7 16.20 (57/72) Installing libidn2-dev (2.3.4-r1)
+#7 16.20 (58/72) Installing nghttp2-dev (1.53.0-r0)
+#7 16.21 (59/72) Installing brotli (1.0.9-r14)
+#7 16.21 (60/72) Installing brotli-dev (1.0.9-r14)
+#7 16.21 (61/72) Installing curl-dev (8.1.2-r0)
+#7 16.22 (62/72) Installing libtiffxx (4.5.1-r0)
+#7 16.22 (63/72) Installing libjpeg-turbo-dev (2.1.5.1-r3)
+#7 16.23 (64/72) Installing libwebp-dev (1.3.1-r0)
+#7 16.23 (65/72) Installing tiff-dev (4.5.1-r0)
+#7 16.23 (66/72) Installing sqlite (3.41.2-r2)
+#7 16.25 (67/72) Installing sqlite-dev (3.41.2-r2)
+#7 16.26 (68/72) Installing proj-dev (9.2.1-r0)
+#7 16.26 (69/72) Installing .build-deps (20230718.064445)
+#7 16.26 (70/72) Installing perl-error (0.17029-r1)
+#7 16.27 (71/72) Installing perl-git (2.40.1-r0)
+#7 16.27 (72/72) Installing git-perl (2.40.1-r0)
+#7 16.28 Executing busybox-1.36.1-r0.trigger
+#7 16.28 Executing ca-certificates-20230506-r0.trigger
+#7 16.67 OK: 1501 MiB in 170 packages
+#7 16.82   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+#7 16.83                                  Dload  Upload   Total   Spent    Left  Speed
+#7 16.83   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0100 2544k  100 2544k    0     0  30.4M      0 --:--:-- --:--:-- --:--:-- 30.6M
+#7 22.31 Collecting pip
+#7 22.31   Obtaining dependency information for pip from https://files.pythonhosted.org/packages/02/65/f15431ddee78562355ccb39097bf9160a1689f2db40dc418754be98806a1/pip-23.2-py3-none-any.whl.metadata
+#7 22.35   Downloading pip-23.2-py3-none-any.whl.metadata (4.2 kB)
+#7 22.37 Downloading pip-23.2-py3-none-any.whl (2.1 MB)
+#7 22.64    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 7.6 MB/s eta 0:00:00
+#7 22.75 Installing collected packages: pip
+#7 22.75   Attempting uninstall: pip
+#7 22.75     Found existing installation: pip 23.0.1
+#7 22.80     Uninstalling pip-23.0.1:
+#7 22.85       Successfully uninstalled pip-23.0.1
+#7 24.31 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#7 24.31 Successfully installed pip-23.2
+#7 26.01 Collecting supervisor
+#7 26.05   Downloading supervisor-4.2.5-py2.py3-none-any.whl (319 kB)
+#7 26.08      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 319.6/319.6 kB 9.7 MB/s eta 0:00:00
+#7 26.10 Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (from supervisor) (58.1.0)
+#7 26.13 Installing collected packages: supervisor
+#7 26.52 Successfully installed supervisor-4.2.5
+#7 26.52 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#7 DONE 27.4s
+
+#9 [ 4/11] COPY setup/supervisord.conf /etc
+#9 sha256:a95f8514aee2d7d79bd08c0fbd12d90b7839db5a389c647ba69e84210235af7d
+#9 DONE 0.3s
+
+#10 [ 5/11] RUN pip3 install -e git+https://github.com/ckan/ckan.git@ckan-2.9.9#egg=ckan &&     cd /srv/app/src/ckan &&     cp who.ini /srv/app &&     pip3 install --no-binary markdown -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt &&     pip3 install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars &&     ckan generate config /srv/app/ckan.ini &&     ckan config-tool /srv/app/ckan.ini "beaker.session.secret = " &&     ckan config-tool /srv/app/ckan.ini "ckan.plugins = image_view text_view recline_view datastore envvars"
+#10 sha256:9a6fac239594807e57b4d1756523f05a9b84a200b66d9757191bcb23d0d1c8ab
+#10 0.888 Obtaining ckan from git+https://github.com/ckan/ckan.git@ckan-2.9.9#egg=ckan
+#10 0.888   Cloning https://github.com/ckan/ckan.git (to revision ckan-2.9.9) to ./src/ckan
+#10 1.010   Running command git clone --filter=blob:none --quiet https://github.com/ckan/ckan.git /srv/app/src/ckan
+#10 8.365   Running command git checkout -q 13c6d752e86f0e3501f953a9fdde15d038bad87b
+#10 10.92   Resolved https://github.com/ckan/ckan.git to commit 13c6d752e86f0e3501f953a9fdde15d038bad87b
+#10 10.93   Installing build dependencies: started
+#10 13.07   Installing build dependencies: finished with status 'done'
+#10 13.07   Checking if build backend supports build_editable: started
+#10 13.25   Checking if build backend supports build_editable: finished with status 'done'
+#10 13.26   Getting requirements to build editable: started
+#10 13.71   Getting requirements to build editable: finished with status 'done'
+#10 13.71   Preparing editable metadata (pyproject.toml): started
+#10 14.23   Preparing editable metadata (pyproject.toml): finished with status 'done'
+#10 14.37 Building wheels for collected packages: ckan
+#10 14.37   Building editable for ckan (pyproject.toml): started
+#10 15.30   Building editable for ckan (pyproject.toml): finished with status 'done'
+#10 15.31   Created wheel for ckan: filename=ckan-2.9.9-0.editable-py3-none-any.whl size=9338 sha256=5e4d460b57ab98b6d3d27405a7826c5fffe6b8499b61421f00607d5b56a17638
+#10 15.31   Stored in directory: /tmp/pip-ephem-wheel-cache-3s50942e/wheels/6c/b1/4d/735daa3e067befb8d6d7324e10f0331771165427d3eee85600
+#10 15.31 Successfully built ckan
+#10 15.57 Installing collected packages: ckan
+#10 15.63 Successfully installed ckan-2.9.9
+#10 15.63 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#10 16.53 Collecting alembic==1.0.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 7))
+#10 16.56   Downloading alembic-1.0.0-py2.py3-none-any.whl (158 kB)
+#10 16.60      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 158.3/158.3 kB 5.3 MB/s eta 0:00:00
+#10 16.63 Collecting babel==2.7.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 8))
+#10 16.64   Downloading Babel-2.7.0-py2.py3-none-any.whl (8.4 MB)
+#10 16.80      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.4/8.4 MB 52.4 MB/s eta 0:00:00
+#10 16.88 Collecting beaker==1.11.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 9))
+#10 16.89   Downloading Beaker-1.11.0.tar.gz (40 kB)
+#10 16.91      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 40.9/40.9 kB 2.0 MB/s eta 0:00:00
+#10 16.92   Preparing metadata (setup.py): started
+#10 17.52   Preparing metadata (setup.py): finished with status 'done'
+#10 17.57 Collecting bleach==3.1.4 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 10))
+#10 17.57   Downloading bleach-3.1.4-py2.py3-none-any.whl (151 kB)
+#10 17.59      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 151.5/151.5 kB 7.9 MB/s eta 0:00:00
+#10 17.63 Collecting certifi==2021.5.30 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 11))
+#10 17.64   Downloading certifi-2021.5.30-py2.py3-none-any.whl (145 kB)
+#10 17.66      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 145.5/145.5 kB 6.1 MB/s eta 0:00:00
+#10 17.69 Collecting chardet==4.0.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 12))
+#10 17.70   Downloading chardet-4.0.0-py2.py3-none-any.whl (178 kB)
+#10 17.72      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 178.7/178.7 kB 7.5 MB/s eta 0:00:00
+#10 17.77 Collecting click==7.1.2 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 13))
+#10 17.77   Downloading click-7.1.2-py2.py3-none-any.whl (82 kB)
+#10 17.79      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 82.8/82.8 kB 4.2 MB/s eta 0:00:00
+#10 17.92 Collecting dominate==2.4.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 14))
+#10 17.92   Downloading dominate-2.4.0-py2.py3-none-any.whl (29 kB)
+#10 17.97 Collecting fanstatic==1.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 15))
+#10 17.98   Downloading fanstatic-1.1.tar.gz (237 kB)
+#10 18.00      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 237.9/237.9 kB 10.8 MB/s eta 0:00:00
+#10 18.03   Preparing metadata (setup.py): started
+#10 18.25   Preparing metadata (setup.py): finished with status 'done'
+#10 18.37 Collecting feedgen==0.9.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 16))
+#10 18.38   Downloading feedgen-0.9.0.tar.gz (217 kB)
+#10 18.40      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 217.9/217.9 kB 11.0 MB/s eta 0:00:00
+#10 18.43   Preparing metadata (setup.py): started
+#10 18.64   Preparing metadata (setup.py): finished with status 'done'
+#10 18.67 Collecting flask-babel==1.0.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 17))
+#10 18.68   Downloading Flask_Babel-1.0.0-py3-none-any.whl (9.5 kB)
+#10 18.73 Collecting flask-multistatic==1.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 18))
+#10 18.73   Downloading flask-multistatic-1.0.tar.gz (15 kB)
+#10 18.75   Preparing metadata (setup.py): started
+#10 18.99   Preparing metadata (setup.py): finished with status 'done'
+#10 19.04 Collecting flask==1.1.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 19))
+#10 19.04   Downloading Flask-1.1.1-py2.py3-none-any.whl (94 kB)
+#10 19.06      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 94.5/94.5 kB 5.2 MB/s eta 0:00:00
+#10 19.08 Collecting funcsigs==1.0.2 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 20))
+#10 19.09   Downloading funcsigs-1.0.2-py2.py3-none-any.whl (17 kB)
+#10 19.13 Collecting idna==2.10 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 21))
+#10 19.14   Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
+#10 19.15      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.8/58.8 kB 3.5 MB/s eta 0:00:00
+#10 19.18 Collecting itsdangerous==1.1.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 22))
+#10 19.19   Downloading itsdangerous-1.1.0-py2.py3-none-any.whl (16 kB)
+#10 19.23 Collecting jinja2==2.10.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 23))
+#10 19.24   Downloading Jinja2-2.10.1-py2.py3-none-any.whl (124 kB)
+#10 19.26      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 124.9/124.9 kB 5.6 MB/s eta 0:00:00
+#10 19.49 Collecting lxml==4.6.3 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 24))
+#10 19.52   Downloading lxml-4.6.3.tar.gz (3.2 MB)
+#10 19.59      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.2/3.2 MB 45.6 MB/s eta 0:00:00
+#10 19.99   Preparing metadata (setup.py): started
+#10 20.37   Preparing metadata (setup.py): finished with status 'done'
+#10 20.41 Collecting mako==1.1.5 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 25))
+#10 20.41   Downloading Mako-1.1.5-py2.py3-none-any.whl (75 kB)
+#10 20.43      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 75.7/75.7 kB 3.5 MB/s eta 0:00:00
+#10 20.47 Collecting markdown==3.4.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 26))
+#10 20.48   Downloading Markdown-3.4.1.tar.gz (322 kB)
+#10 20.50      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 322.6/322.6 kB 17.0 MB/s eta 0:00:00
+#10 20.63   Installing build dependencies: started
+#10 22.65   Installing build dependencies: finished with status 'done'
+#10 22.66   Getting requirements to build wheel: started
+#10 22.86   Getting requirements to build wheel: finished with status 'done'
+#10 22.87   Preparing metadata (pyproject.toml): started
+#10 23.10   Preparing metadata (pyproject.toml): finished with status 'done'
+#10 23.21 Collecting markupsafe==1.1.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 27))
+#10 23.22   Downloading MarkupSafe-1.1.1.tar.gz (19 kB)
+#10 23.24   Preparing metadata (setup.py): started
+#10 23.45   Preparing metadata (setup.py): finished with status 'done'
+#10 23.48 Collecting nose==1.3.7 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 28))
+#10 23.49   Downloading nose-1.3.7-py3-none-any.whl (154 kB)
+#10 23.51      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 154.7/154.7 kB 9.3 MB/s eta 0:00:00
+#10 23.53 Collecting passlib==1.6.5 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 29))
+#10 23.54   Downloading passlib-1.6.5-py2.py3-none-any.whl (317 kB)
+#10 23.56      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 317.6/317.6 kB 14.9 MB/s eta 0:00:00
+#10 23.59 Collecting polib==1.0.7 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 30))
+#10 23.60   Downloading polib-1.0.7-py2.py3-none-any.whl (24 kB)
+#10 23.69 Collecting psycopg2==2.9.3 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 31))
+#10 23.70   Downloading psycopg2-2.9.3.tar.gz (380 kB)
+#10 23.73      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 380.6/380.6 kB 16.2 MB/s eta 0:00:00
+#10 23.81   Preparing metadata (setup.py): started
+#10 24.07   Preparing metadata (setup.py): finished with status 'done'
+#10 24.12 Collecting pyjwt==1.7.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 32))
+#10 24.13   Downloading PyJWT-1.7.1-py2.py3-none-any.whl (18 kB)
+#10 24.26 Collecting pysolr==3.6.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 33))
+#10 24.26   Downloading pysolr-3.6.0-py2.py3-none-any.whl (18 kB)
+#10 24.31 Collecting python-dateutil==2.8.2 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 34))
+#10 24.31   Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
+#10 24.33      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 13.9 MB/s eta 0:00:00
+#10 24.35 Collecting python-editor==1.0.4 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 35))
+#10 24.36   Downloading python_editor-1.0.4-py3-none-any.whl (4.9 kB)
+#10 24.41 Collecting python-magic==0.4.15 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 36))
+#10 24.41   Downloading python_magic-0.4.15-py2.py3-none-any.whl (5.5 kB)
+#10 24.51 Collecting pytz==2016.7 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 37))
+#10 24.52   Downloading pytz-2016.7-py2.py3-none-any.whl (480 kB)
+#10 24.54      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 480.7/480.7 kB 21.9 MB/s eta 0:00:00
+#10 24.66 Collecting pyutilib==5.7.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 38))
+#10 24.67   Downloading PyUtilib-5.7.1-py2.py3-none-any.whl (251 kB)
+#10 24.69      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 251.1/251.1 kB 13.2 MB/s eta 0:00:00
+#10 24.75 Collecting pyyaml==6.0.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 39))
+#10 24.76   Downloading PyYAML-6.0.1.tar.gz (125 kB)
+#10 24.78      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.2/125.2 kB 7.2 MB/s eta 0:00:00
+#10 24.97   Installing build dependencies: started
+#10 28.81   Installing build dependencies: finished with status 'done'
+#10 28.81   Getting requirements to build wheel: started
+#10 29.79   Getting requirements to build wheel: finished with status 'done'
+#10 29.79   Preparing metadata (pyproject.toml): started
+#10 30.06   Preparing metadata (pyproject.toml): finished with status 'done'
+#10 30.14 Collecting redis==3.5.3 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 40))
+#10 30.14   Downloading redis-3.5.3-py2.py3-none-any.whl (72 kB)
+#10 30.16      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72.1/72.1 kB 4.0 MB/s eta 0:00:00
+#10 30.19 Collecting repoze.lru==0.7 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 41))
+#10 30.19   Downloading repoze.lru-0.7-py3-none-any.whl (10 kB)
+#10 30.31 Collecting repoze.who==2.3 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 42))
+#10 30.32   Downloading repoze.who-2.3-py3-none-any.whl (75 kB)
+#10 30.34      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 75.4/75.4 kB 4.5 MB/s eta 0:00:00
+#10 30.42 Collecting requests==2.25.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 43))
+#10 30.43   Downloading requests-2.25.1-py2.py3-none-any.whl (61 kB)
+#10 30.45      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 kB 3.5 MB/s eta 0:00:00
+#10 30.48 Collecting routes==1.13 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 44))
+#10 30.49   Downloading Routes-1.13.tar.gz (797 kB)
+#10 30.52      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 797.5/797.5 kB 27.0 MB/s eta 0:00:00
+#10 30.59   Preparing metadata (setup.py): started
+#10 30.80   Preparing metadata (setup.py): finished with status 'done'
+#10 30.85 Collecting rq==1.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 45))
+#10 30.85   Downloading rq-1.0.tar.gz (45 kB)
+#10 30.87      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 45.5/45.5 kB 2.5 MB/s eta 0:00:00
+#10 30.88   Preparing metadata (setup.py): started
+#10 31.09   Preparing metadata (setup.py): finished with status 'done'
+#10 31.11 Collecting shutilwhich==1.1.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 46))
+#10 31.12   Downloading shutilwhich-1.1.0.tar.gz (2.3 kB)
+#10 31.14   Preparing metadata (setup.py): started
+#10 31.34   Preparing metadata (setup.py): finished with status 'done'
+#10 31.55 Collecting simplejson==3.10.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 47))
+#10 31.55   Downloading simplejson-3.10.0.tar.gz (77 kB)
+#10 31.58      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.0/78.0 kB 4.0 MB/s eta 0:00:00
+#10 31.63   Preparing metadata (setup.py): started
+#10 31.88   Preparing metadata (setup.py): finished with status 'done'
+#10 31.91 Collecting six==1.16.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 48))
+#10 31.92   Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
+#10 32.31 Collecting sqlalchemy==1.3.5 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 49))
+#10 32.33   Downloading SQLAlchemy-1.3.5.tar.gz (5.9 MB)
+#10 32.44      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.9/5.9 MB 55.5 MB/s eta 0:00:00
+#10 33.15   Preparing metadata (setup.py): started
+#10 33.61   Preparing metadata (setup.py): finished with status 'done'
+#10 33.88 Collecting sqlparse==0.3.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 50))
+#10 33.88   Downloading sqlparse-0.3.0-py2.py3-none-any.whl (39 kB)
+#10 33.95 Collecting tzlocal==1.3 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 51))
+#10 33.95   Downloading tzlocal-1.3.tar.gz (18 kB)
+#10 33.98   Preparing metadata (setup.py): started
+#10 34.20   Preparing metadata (setup.py): finished with status 'done'
+#10 34.23 Collecting unicodecsv==0.14.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 52))
+#10 34.24   Downloading unicodecsv-0.14.1.tar.gz (10 kB)
+#10 34.27   Preparing metadata (setup.py): started
+#10 34.47   Preparing metadata (setup.py): finished with status 'done'
+#10 34.54 Collecting urllib3==1.26.6 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 53))
+#10 34.54   Downloading urllib3-1.26.6-py2.py3-none-any.whl (138 kB)
+#10 34.56      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 138.5/138.5 kB 8.3 MB/s eta 0:00:00
+#10 34.63 Collecting watchdog==2.1.5 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 54))
+#10 34.64   Downloading watchdog-2.1.5.tar.gz (114 kB)
+#10 34.66      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 114.2/114.2 kB 6.8 MB/s eta 0:00:00
+#10 34.69   Preparing metadata (setup.py): started
+#10 34.91   Preparing metadata (setup.py): finished with status 'done'
+#10 35.02 Collecting webassets==0.12.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 55))
+#10 35.02   Downloading webassets-0.12.1.tar.gz (179 kB)
+#10 35.04      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 179.4/179.4 kB 10.3 MB/s eta 0:00:00
+#10 35.11   Preparing metadata (setup.py): started
+#10 35.33   Preparing metadata (setup.py): finished with status 'done'
+#10 35.35 Collecting webencodings==0.5.1 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 56))
+#10 35.36   Downloading webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
+#10 35.42 Collecting webob==1.8.7 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 57))
+#10 35.43   Downloading WebOb-1.8.7-py2.py3-none-any.whl (114 kB)
+#10 35.45      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 115.0/115.0 kB 6.8 MB/s eta 0:00:00
+#10 35.49 Collecting werkzeug[watchdog]==1.0.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 58))
+#10 35.50   Downloading Werkzeug-1.0.0-py2.py3-none-any.whl (298 kB)
+#10 35.52      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 298.6/298.6 kB 14.9 MB/s eta 0:00:00
+#10 35.67 Collecting zope-interface==5.4.0 (from -r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 59))
+#10 35.68   Downloading zope.interface-5.4.0.tar.gz (249 kB)
+#10 35.71      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 249.3/249.3 kB 9.3 MB/s eta 0:00:00
+#10 35.78   Preparing metadata (setup.py): started
+#10 36.01   Preparing metadata (setup.py): finished with status 'done'
+#10 36.08 Requirement already satisfied: setuptools in /usr/local/lib/python3.9/site-packages (from fanstatic==1.1->-r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 15)) (58.1.0)
+#10 36.13 Collecting Werkzeug>=0.15 (from flask==1.1.1->-r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 19))
+#10 36.13   Obtaining dependency information for Werkzeug>=0.15 from https://files.pythonhosted.org/packages/ba/d6/8040faecaba2feb84e1647af174b3243c9b90c163c7ea407820839931efe/Werkzeug-2.3.6-py3-none-any.whl.metadata
+#10 36.13   Downloading Werkzeug-2.3.6-py3-none-any.whl.metadata (4.1 kB)
+#10 36.35 Collecting importlib-metadata>=4.4 (from markdown==3.4.1->-r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 26))
+#10 36.35   Obtaining dependency information for importlib-metadata>=4.4 from https://files.pythonhosted.org/packages/cc/37/db7ba97e676af155f5fcb1a35466f446eadc9104e25b83366e8088c9c926/importlib_metadata-6.8.0-py3-none-any.whl.metadata
+#10 36.35   Downloading importlib_metadata-6.8.0-py3-none-any.whl.metadata (5.1 kB)
+#10 36.95 Collecting zipp>=0.5 (from importlib-metadata>=4.4->markdown==3.4.1->-r https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt (line 26))
+#10 36.95   Obtaining dependency information for zipp>=0.5 from https://files.pythonhosted.org/packages/8c/08/d3006317aefe25ea79d3b76c9650afabaf6d63d1c8443b236e7405447503/zipp-3.16.2-py3-none-any.whl.metadata
+#10 36.96   Downloading zipp-3.16.2-py3-none-any.whl.metadata (3.7 kB)
+#10 37.09 Downloading importlib_metadata-6.8.0-py3-none-any.whl (22 kB)
+#10 37.11 Downloading zipp-3.16.2-py3-none-any.whl (7.2 kB)
+#10 37.13 Building wheels for collected packages: beaker, fanstatic, feedgen, flask-multistatic, lxml, markdown, markupsafe, psycopg2, pyyaml, routes, rq, shutilwhich, simplejson, sqlalchemy, tzlocal, unicodecsv, watchdog, webassets, zope-interface
+#10 37.13   Building wheel for beaker (setup.py): started
+#10 37.56   Building wheel for beaker (setup.py): finished with status 'done'
+#10 37.56   Created wheel for beaker: filename=Beaker-1.11.0-py3-none-any.whl size=51554 sha256=c6e8762dfab045e6ee021473e533ddb3b4f55383dc956e5f8dc30269b020b405
+#10 37.57   Stored in directory: /root/.cache/pip/wheels/11/51/aa/270563f5752b4d328534aea048fb45d5e7c782fc80157f3b69
+#10 37.57   Building wheel for fanstatic (setup.py): started
+#10 37.95   Building wheel for fanstatic (setup.py): finished with status 'done'
+#10 37.95   Created wheel for fanstatic: filename=fanstatic-1.1-py3-none-any.whl size=31969 sha256=cc14a172f0534d4f9c6a3c95262fec638f87ec3a105caaa6944b96a09c0c04ae
+#10 37.95   Stored in directory: /root/.cache/pip/wheels/84/dd/81/ec36f329637c0caf4fb94d25110241f5c3d648878f9bd04ed8
+#10 37.95   Building wheel for feedgen (setup.py): started
+#10 38.37   Building wheel for feedgen (setup.py): finished with status 'done'
+#10 38.37   Created wheel for feedgen: filename=feedgen-0.9.0-py2.py3-none-any.whl size=44384 sha256=eae73b9ee0849d5f5c8af254242cbe74dcba909e7f84bfb81bfd05076f1867d7
+#10 38.37   Stored in directory: /root/.cache/pip/wheels/f5/e1/0c/e7f6d7602caeffb70f544de8376a5e8fb966b43b4ef17860a7
+#10 38.38   Building wheel for flask-multistatic (setup.py): started
+#10 38.66   Building wheel for flask-multistatic (setup.py): finished with status 'done'
+#10 38.66   Created wheel for flask-multistatic: filename=flask_multistatic-1.0-py3-none-any.whl size=15208 sha256=2bcaa3f1647f61d8456bb3626233c7576f6b8baea978d0e01cc841fee391a2fe
+#10 38.66   Stored in directory: /root/.cache/pip/wheels/d9/f9/ee/c1d802aaf24a12240ec4814bd85ad86d22af2c3c9fc9ce61f3
+#10 38.66   Building wheel for lxml (setup.py): started
+#10 143.0   Building wheel for lxml (setup.py): still running...
+#10 202.6   Building wheel for lxml (setup.py): finished with status 'done'
+#10 202.6   Created wheel for lxml: filename=lxml-4.6.3-cp39-cp39-linux_x86_64.whl size=8135059 sha256=8d87c9ac9ed4b18294edbe5480bd1810d356a5f8094141b8c3b4a0c64b546bbf
+#10 202.6   Stored in directory: /root/.cache/pip/wheels/6c/21/10/6efb7c8c644d8aecc1a85554f10af608c3c70a48f4836c375e
+#10 202.6   Building wheel for markdown (pyproject.toml): started
+#10 203.2   Building wheel for markdown (pyproject.toml): finished with status 'done'
+#10 203.2   Created wheel for markdown: filename=Markdown-3.4.1-py3-none-any.whl size=93293 sha256=52b7ea62c7aa69c811c46908fc0857c4e3873eff6b67771128436ff43e7c8d3a
+#10 203.2   Stored in directory: /root/.cache/pip/wheels/5c/5e/a4/50340941887df9d898e71b1d23e1c8c94d6d85ff9eef693528
+#10 203.2   Building wheel for markupsafe (setup.py): started
+#10 203.9   Building wheel for markupsafe (setup.py): finished with status 'done'
+#10 203.9   Created wheel for markupsafe: filename=MarkupSafe-1.1.1-cp39-cp39-linux_x86_64.whl size=27693 sha256=c98e514f0c02d65b68bd0d8e92875cf17a6493e38b97a5145934db3d22afab95
+#10 203.9   Stored in directory: /root/.cache/pip/wheels/e0/19/6f/6ba857621f50dc08e084312746ed3ebc14211ba30037d5e44e
+#10 203.9   Building wheel for psycopg2 (setup.py): started
+#10 212.8   Building wheel for psycopg2 (setup.py): finished with status 'done'
+#10 212.8   Created wheel for psycopg2: filename=psycopg2-2.9.3-cp39-cp39-linux_x86_64.whl size=466219 sha256=5e176d7a04f90e753d760af60962d1562745f1b65d625c52550100eaf0a07b96
+#10 212.8   Stored in directory: /root/.cache/pip/wheels/b3/a1/6e/5a0e26314b15eb96a36263b80529ce0d64382540ac7b9544a9
+#10 212.8   Building wheel for pyyaml (pyproject.toml): started
+#10 213.4   Building wheel for pyyaml (pyproject.toml): finished with status 'done'
+#10 213.4   Created wheel for pyyaml: filename=PyYAML-6.0.1-cp39-cp39-linux_x86_64.whl size=45361 sha256=b44e34a9bf57b59ab0da282fc3df655e4e10cbcd870c3250326ed0b65af2f56b
+#10 213.4   Stored in directory: /root/.cache/pip/wheels/1c/ff/88/3a317d1db793206ab64cb66367bf6f84186b75849656be786a
+#10 213.4   Building wheel for routes (setup.py): started
+#10 213.9   Building wheel for routes (setup.py): finished with status 'done'
+#10 213.9   Created wheel for routes: filename=Routes-1.13-py3-none-any.whl size=30162 sha256=3b047cf6a1eb9fa5de20c5abce0f6c2e33f5e91c7dcb9805a0b9b8acfc661896
+#10 213.9   Stored in directory: /root/.cache/pip/wheels/f4/58/7d/7aeb2edb388276e6047289cd2b1f2f14cc3d53718bbce817d5
+#10 213.9   Building wheel for rq (setup.py): started
+#10 214.3   Building wheel for rq (setup.py): finished with status 'done'
+#10 214.3   Created wheel for rq: filename=rq-1.0-py2.py3-none-any.whl size=52919 sha256=b10e77c2eb0e10cb7afc41562f42482b798f6269f6a2fb809e92a6a7041eb6f2
+#10 214.3   Stored in directory: /root/.cache/pip/wheels/c9/b7/21/12fd1da8031461560678f10f8080ff1592ae8471bd288ab6de
+#10 214.3   Building wheel for shutilwhich (setup.py): started
+#10 214.5   Building wheel for shutilwhich (setup.py): finished with status 'done'
+#10 214.5   Created wheel for shutilwhich: filename=shutilwhich-1.1.0-py3-none-any.whl size=2782 sha256=09169153188632a2a2d32dde1cb3f121678f484f4c541a59d29d8635e47549a0
+#10 214.5   Stored in directory: /root/.cache/pip/wheels/84/c7/f5/fed66dce1ed897b44e0da776b6a592dfad0a70f7dd61f73a9d
+#10 214.5   Building wheel for simplejson (setup.py): started
+#10 216.4   Building wheel for simplejson (setup.py): finished with status 'done'
+#10 216.4   Created wheel for simplejson: filename=simplejson-3.10.0-cp39-cp39-linux_x86_64.whl size=125494 sha256=ca2411b0fb26c8879c8dc08e23708d26a59003965f551e414ece99f4b50a204a
+#10 216.4   Stored in directory: /root/.cache/pip/wheels/e2/b3/5f/9a1410845877be0f5bc9750650f73cd929d164d295a7ed0406
+#10 216.4   Building wheel for sqlalchemy (setup.py): started
+#10 218.3   Building wheel for sqlalchemy (setup.py): finished with status 'done'
+#10 218.3   Created wheel for sqlalchemy: filename=SQLAlchemy-1.3.5-cp39-cp39-linux_x86_64.whl size=1174678 sha256=80ead7c6d9d55793479acb995f43ac63a255cbf2c224cabfe89765672799cd85
+#10 218.3   Stored in directory: /root/.cache/pip/wheels/4a/d4/46/df4abee981bb0e8a6b1da4cdb269661ff0010d988b61d96c37
+#10 218.3   Building wheel for tzlocal (setup.py): started
+#10 218.7   Building wheel for tzlocal (setup.py): finished with status 'done'
+#10 218.7   Created wheel for tzlocal: filename=tzlocal-1.3-py3-none-any.whl size=18066 sha256=c6bbfb79758737860cf47a71743860817b234add7c4affaff8c39784329b1e2c
+#10 218.7   Stored in directory: /root/.cache/pip/wheels/f2/99/1c/154c574b470e94db9a215a067f36c49d1921a1a15a907bff13
+#10 218.7   Building wheel for unicodecsv (setup.py): started
+#10 219.0   Building wheel for unicodecsv (setup.py): finished with status 'done'
+#10 219.0   Created wheel for unicodecsv: filename=unicodecsv-0.14.1-py3-none-any.whl size=10767 sha256=56db96b2cf8a21f4ef6d8f611cbc1fee62430bb0c755ce07ac5c758c3a7202c6
+#10 219.0   Stored in directory: /root/.cache/pip/wheels/d8/c8/27/b237d3378d5c9ed25c2c63d9af1b3d5ccb99934f3dd030de87
+#10 219.0   Building wheel for watchdog (setup.py): started
+#10 219.3   Building wheel for watchdog (setup.py): finished with status 'done'
+#10 219.3   Created wheel for watchdog: filename=watchdog-2.1.5-py3-none-any.whl size=75557 sha256=c560b1de8c553d79e74c3240fb0ba10756fa95e7fb8a2e555147bd4b5b80c58d
+#10 219.3   Stored in directory: /root/.cache/pip/wheels/5e/8d/c8/be6760a49f9b1cc14dcba82b900ad7713909bcee3005b05317
+#10 219.3   Building wheel for webassets (setup.py): started
+#10 219.6   Building wheel for webassets (setup.py): finished with status 'done'
+#10 219.6   Created wheel for webassets: filename=webassets-0.12.1-py3-none-any.whl size=136807 sha256=3ed922e17342bc6b7ec206b6eb232a668842f42ba3d5f2a5eec8c8d5ddba6aa0
+#10 219.6   Stored in directory: /root/.cache/pip/wheels/e4/91/15/4e25f23daef790afc61c43a8063fe6f52fb2d9476b02a600b9
+#10 219.6   Building wheel for zope-interface (setup.py): started
+#10 220.8   Building wheel for zope-interface (setup.py): finished with status 'done'
+#10 220.8   Created wheel for zope-interface: filename=zope.interface-5.4.0-cp39-cp39-linux_x86_64.whl size=248483 sha256=0bcef7dfa4e0b6a45bd5c2440f334a8cbe4b36967df5f92aaa4a65824d801d5a
+#10 220.8   Stored in directory: /root/.cache/pip/wheels/d8/ed/86/a6eaafa489d679f58d58a488b372b1518a30755f21121806ac
+#10 220.8 Successfully built beaker fanstatic feedgen flask-multistatic lxml markdown markupsafe psycopg2 pyyaml routes rq shutilwhich simplejson sqlalchemy tzlocal unicodecsv watchdog webassets zope-interface
+#10 221.3 Installing collected packages: webencodings, webassets, unicodecsv, simplejson, shutilwhich, repoze.lru, pytz, python-magic, python-editor, pyjwt, polib, passlib, nose, funcsigs, certifi, beaker, zope-interface, zipp, werkzeug, webob, watchdog, urllib3, tzlocal, sqlparse, sqlalchemy, six, routes, redis, pyyaml, psycopg2, markupsafe, lxml, itsdangerous, idna, dominate, click, chardet, babel, rq, requests, repoze.who, pyutilib, python-dateutil, mako, jinja2, importlib-metadata, fanstatic, bleach, pysolr, markdown, flask, feedgen, alembic, flask-multistatic, flask-babel
+#10 228.4 Successfully installed alembic-1.0.0 babel-2.7.0 beaker-1.11.0 bleach-3.1.4 certifi-2021.5.30 chardet-4.0.0 click-7.1.2 dominate-2.4.0 fanstatic-1.1 feedgen-0.9.0 flask-1.1.1 flask-babel-1.0.0 flask-multistatic-1.0 funcsigs-1.0.2 idna-2.10 importlib-metadata-6.8.0 itsdangerous-1.1.0 jinja2-2.10.1 lxml-4.6.3 mako-1.1.5 markdown-3.4.1 markupsafe-1.1.1 nose-1.3.7 passlib-1.6.5 polib-1.0.7 psycopg2-2.9.3 pyjwt-1.7.1 pysolr-3.6.0 python-dateutil-2.8.2 python-editor-1.0.4 python-magic-0.4.15 pytz-2016.7 pyutilib-5.7.1 pyyaml-6.0.1 redis-3.5.3 repoze.lru-0.7 repoze.who-2.3 requests-2.25.1 routes-1.13 rq-1.0 shutilwhich-1.1.0 simplejson-3.10.0 six-1.16.0 sqlalchemy-1.3.5 sqlparse-0.3.0 tzlocal-1.3 unicodecsv-0.14.1 urllib3-1.26.6 watchdog-2.1.5 webassets-0.12.1 webencodings-0.5.1 webob-1.8.7 werkzeug-1.0.0 zipp-3.16.2 zope-interface-5.4.0
+#10 228.4 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#10 229.4 Obtaining ckanext-envvars from git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars
+#10 229.4   Cloning https://github.com/okfn/ckanext-envvars.git to /srv/app/src/ckanext-envvars
+#10 229.5   Running command git clone --filter=blob:none --quiet https://github.com/okfn/ckanext-envvars.git /srv/app/src/ckanext-envvars
+#10 230.7   Resolved https://github.com/okfn/ckanext-envvars.git to commit f63865e3049090a55bbea6909cff93d2662958e7
+#10 230.7   Preparing metadata (setup.py): started
+#10 231.0   Preparing metadata (setup.py): finished with status 'done'
+#10 231.1 Collecting ckantoolkit (from ckanext-envvars)
+#10 231.1   Downloading ckantoolkit-0.0.7.tar.gz (2.8 kB)
+#10 231.2   Preparing metadata (setup.py): started
+#10 231.4   Preparing metadata (setup.py): finished with status 'done'
+#10 231.4 Requirement already satisfied: six in /usr/local/lib/python3.9/site-packages (from ckantoolkit->ckanext-envvars) (1.16.0)
+#10 231.4 Building wheels for collected packages: ckantoolkit
+#10 231.4   Building wheel for ckantoolkit (setup.py): started
+#10 231.7   Building wheel for ckantoolkit (setup.py): finished with status 'done'
+#10 231.7   Created wheel for ckantoolkit: filename=ckantoolkit-0.0.7-py3-none-any.whl size=3471 sha256=d324bf30fbe2e70fedaaed5eda9911abeefaa6469126e461a859f9ffb862bc59
+#10 231.7   Stored in directory: /root/.cache/pip/wheels/93/36/cd/0f696a133f865e9f93aa74c285e152f29454df72b415ea0221
+#10 231.7 Successfully built ckantoolkit
+#10 232.2 Installing collected packages: ckantoolkit, ckanext-envvars
+#10 232.2   Running setup.py develop for ckanext-envvars
+#10 232.6 Successfully installed ckanext-envvars-0.0.3 ckantoolkit-0.0.7
+#10 232.6 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+#10 235.3 Edited option beaker.session.secret = "tkLrFTggxjwYYccOhDVQoiC4Z"->"" (section "app:main")
+#10 236.3 Edited option ckan.plugins = "stats text_view image_view recline_view"->"image_view text_view recline_view datastore envvars" (section "app:main")
+#10 DONE 237.0s
+
+#11 [ 6/11] RUN addgroup -g 92 -S ckan &&     adduser -u 92 -h /home/ckan -s /bin/bash -D -G ckan ckan
+#11 sha256:addf6490dd640f74070f85ad2dc1a4bfe087faa7dccb2ca69d0250ea9f4b5e95
+#11 DONE 0.9s
+
+#12 [ 7/11] RUN mkdir -p /var/lib/ckan &&     chown -R ckan:ckan /var/lib/ckan
+#12 sha256:040f8ffff9835db4a4b29b2ce516772ea6964fa84b0b32217b671747ad7d0809
+#12 DONE 0.7s
+
+#13 [ 8/11] COPY setup/prerun.py /srv/app
+#13 sha256:42ba26fb6a88106f0f8580fd7e81755d05c1811a4d070eb989901918114004bb
+#13 DONE 0.3s
+
+#14 [ 9/11] COPY setup/start_ckan.sh /srv/app
+#14 sha256:4152d9e1e5cb3f877236d11d5201d5e23a21e4d7eae2ec9a8aafda48487906c7
+#14 DONE 0.2s
+
+#16 [10/11] ADD https://raw.githubusercontent.com/ckan/ckan/ckan-2.9.9/wsgi.py /srv/app
+#16 sha256:934b284e87a6a8eb4536f64daa90aa6467da32f0327e2065ddfd14e64f341ba4
+#16 DONE 0.3s
+
+#17 [11/11] RUN chmod 644 /srv/app/wsgi.py
+#17 sha256:5f7f70e8ec268c8f0055ae0cbda628c63c654715314993d053d3d55639ad8d84
+#17 DONE 0.6s
+
+#18 exporting to image
+#18 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
+#18 exporting layers
+#18 exporting layers 32.8s done
+#18 writing image sha256:1574bc2e181e9b78eed34776c23c61c867ff5e16fc56c19c3ccda242388d4c0d 0.0s done
+#18 DONE 32.9s


### PR DESCRIPTION
## Update image
`alpine-18` to `python:3.9-alpine3.18` to avoid errors with: 

1. proj4 > 9.0.0 only in `alpine-16` (`pyproj 3.6.0` now minimun version for `ckanext-spatial` https://github.com/pyproj4/pyproj/issues/1321
3. alpine-16 contains > Python 3.9 and `ckanext-ennvars` fails: `cannot import name 'MutableMapping' from 'collections'`

    >Deprecated since version 3.3, will be removed in version 3.10: Moved [Collections Abstract Base Classes](https://docs.python.org/3.9/library/collections.abc.html#collections-abstract-base-classes) >to the [collections.abc](https://docs.python.org/3.9/library/collections.abc.html#module-collections.abc) module. For backwards compatibility, they continue to be visible in this module >through Python 3.9.
    >
    >Ref. https://docs.python.org/3.9/library/collections.html

## Update [requirements.txt](https://gist.githubusercontent.com/mjanez/4e0b99543014cb5ad1d739a0a6e0a419/raw/693c7199c4eb6ceb87c557a5070d2fb40c19eb1a/requirements.txt) 
Update libraries

1. pyyaml error: https://github.com/yaml/pyyaml/issues/724 Update to: `pyyaml==6.0.1`
4. zope-interface error. Update to: `zope-interface==5.4.0`

## Removes setuptools install
Removes requirement-setuptools.txt since we're compatible with all recent versions of setuptools.

