### PR TITLE
Update Dockerfile to use Debian and fix netcat installation

### DIFF
--- a/ckan-2.9/test/Dockerfile
+++ b/ckan-2.9/test/Dockerfile
@@ -6,7 +6,7 @@ ENV APP_DIR=/srv/app
 ENV SRC_DIR=${APP_DIR}/src
 ENV CKAN_DIR=${SRC_DIR}/ckan
 ENV CKAN_TEST_INI=${APP_DIR}/test.ini
-ENV NODE_MAJOR_VERSION="18"
+ENV NODE_VERSION="18"
 ENV TZ=UTC
 # Custom scripts from Natural History Museum: https://github.com/NaturalHistoryMuseum/nhm-docker-ckan
 ARG REPO_NAME=ckan-docker-spatial
@@ -14,12 +14,19 @@ ARG REPO_URL=https://github.com/mjanez/${REPO_NAME}.git
 ARG REPO_BRANCH=ckan-2.9.11-test
 
 # Install packages needed by test requirements
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libffi-dev \
-    netcat \
-    util-linux \
-    libsasl2-dev \
-    libssl-dev \
+RUN RUN apt-get update && apt-get install -y --no-install-recommends \
+        # install packages for additional bits and bobs (like the entrypoint script)
+        wget \
+        git \
+        curl \
+        netcat \
+        uuid-runtime \
+        libffi-dev \
+        netcat-openbsd \
+        util-linux \
+        libsasl2-dev \
+        libssl-dev \
+    && apt-get -q clean \
     && rm -rf /var/lib/apt/lists/*
 
 ## Copy test_ckan.sh
@@ -32,13 +39,9 @@ RUN if [ "$CKAN_VERSION" = "2.9" ]; then \
     fi
 
 # Install NodeJS
-WORKDIR /usr/local
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR_VERSION}.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && npm update -g npm \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -sL "https://deb.nodesource.com/setup_${NODE_VERSION}.x" | bash && \
+    apt-get install -q -y nodejs && \
+    npm update -g npm
 
 # Clone the repository and copy the required folders for nhm custom scripts
 WORKDIR /tmp

--- a/ckan-2.9/test/Dockerfile
+++ b/ckan-2.9/test/Dockerfile
@@ -14,12 +14,11 @@ ARG REPO_URL=https://github.com/mjanez/${REPO_NAME}.git
 ARG REPO_BRANCH=ckan-2.9.11-test
 
 # Install packages needed by test requirements
-RUN RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         # install packages for additional bits and bobs (like the entrypoint script)
         wget \
         git \
         curl \
-        netcat \
         uuid-runtime \
         libffi-dev \
         netcat-openbsd \
@@ -65,9 +64,6 @@ RUN pip3 install --no-cache-dir -r dev-requirements.txt && \
     npm install . --only=prod 
 
 WORKDIR ${APP_DIR}
-
-# Replace default path to CKAN core config file with the one on the container
-RUN sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
 # Run the tests
 CMD ["/bin/sh", "-c", "$APP_DIR/test_ckan.sh"]


### PR DESCRIPTION
[Update Dockerfile to use Debian and fix netcat installation](https://github.com/mjanez/ckan-docker-spatial/commit/9333a414152722e5c5a886c5526eefdda96de83a) 

- Switch base image to ckan/ckan-dev:2.9-py3.9
- Set environment variables for CKAN version, directories, and NodeJS version
- Install necessary packages including netcat-openbsd instead of netcat
- Copy and set permissions for test_ckan.sh script
- Conditionally install pytest-rerunfailures if CKAN version is 2.9
- Install NodeJS using NodeSource setup script
- Clone repository and copy custom scripts from Natural History Museum
- Update pip to the latest version
- Install CKAN test requirements and NodeJS dependencies
- Replace default path to CKAN core config file in test.ini
- Set CMD to run test_ckan.sh script
@[mjanez](https://github.com/mjanez/ckan-docker-spatial/commits?author=mjanez)
mjanez committed now