### PR TITLE
Add continue-on-error to Python Dockerfile linting step

### DIFF
--- a/.github/workflows/docker-build.py.yml
+++ b/.github/workflows/docker-build.py.yml
@@ -48,8 +48,8 @@ jobs:
               echo "DOCKERFILE=${REAL_DOCKERFILE_NAME}" >> $GITHUB_ENV
             else
               BRANCH_VERSION=$(echo "${{ env.BRANCH }}" | sed 's/ckan-//')
-              if [[ $(echo "$BRANCH_VERSION > 2.11" | bc -l) -eq 1 ]]; then
-                echo "No Dockerfile.py3.* found for branch version > 2.11. Exiting successfully."
+              if [[ $(echo "$BRANCH_VERSION >= 2.11" | bc -l) -eq 1 ]]; then
+                echo "No Dockerfile.py3.* found for branch version >= 2.11. Exiting successfully."
                 exit 0
               else
                 echo "No Dockerfile.py3.* found. Exiting."
@@ -146,8 +146,8 @@ jobs:
               echo "DOCKERFILE=${REAL_DOCKERFILE_NAME}" >> $GITHUB_ENV
             else
               BRANCH_VERSION=$(echo "${{ env.BRANCH }}" | sed 's/ckan-//')
-              if [[ $(echo "$BRANCH_VERSION > 2.11" | bc -l) -eq 1 ]]; then
-                echo "No Dockerfile.py3.* found for branch version > 2.11. Exiting successfully."
+              if [[ $(echo "$BRANCH_VERSION >= 2.11" | bc -l) -eq 1 ]]; then
+                echo "No Dockerfile.py3.* found for branch version >= 2.11. Exiting successfully."
                 exit 0
               else
                 echo "No Dockerfile.py3.* found. Exiting."


### PR DESCRIPTION
- Updated the linting step for the Python Dockerfile to include `continue-on-error: true`.
- This ensures that the workflow continues even if the Python Dockerfile linting step fails.
- Modified the determine_dockerfile step to handle the absence of Dockerfile.py3.* gracefully by extracting the branch version and exiting with code 0 for versions >= 2.11 and code 1 otherwise.