### PR TITLE
Add steps to build, push, and lint test Docker image

### DIFF
--- a/.github/workflows/docker-build.py.yml
+++ b/.github/workflows/docker-build.py.yml
@@ -50,7 +50,7 @@ jobs:
               BRANCH_VERSION=$(echo "${{ env.BRANCH }}" | sed 's/ckan-//')
               if [[ $(echo "$BRANCH_VERSION >= 2.11" | bc -l) -eq 1 ]]; then
                 echo "No Dockerfile.py3.* found for branch version >= 2.11. Exiting successfully."
-                exit 0
+                echo "exit_early=true" >> $GITHUB_ENV
               else
                 echo "No Dockerfile.py3.* found. Exiting."
                 exit 1
@@ -58,6 +58,14 @@ jobs:
             fi
           else
             echo "DOCKERFILE=${{ env.DOCKERFILE }}" >> $GITHUB_ENV
+          fi
+
+      - name: Check if should exit early
+        id: check_exit_early
+        run: |
+          if [[ "${{ env.exit_early }}" == "true" ]]; then
+            echo "Exiting early."
+            exit 0
           fi
 
       - name: Extract CKAN_VERSION from base Dockerfile
@@ -128,6 +136,7 @@ jobs:
     name: Build and push development image from base
     runs-on: ubuntu-latest
     needs: build_and_push_base
+    if: needs.build_and_push_base.outputs.exit_early != 'true'
     env:
       CKAN_VERSION: ${{ needs.build_and_push_base.outputs.ckan_version }}
       DOCKER_LABELS: ${{ needs.build_and_push_base.outputs.docker_labels }}
@@ -148,7 +157,7 @@ jobs:
               BRANCH_VERSION=$(echo "${{ env.BRANCH }}" | sed 's/ckan-//')
               if [[ $(echo "$BRANCH_VERSION >= 2.11" | bc -l) -eq 1 ]]; then
                 echo "No Dockerfile.py3.* found for branch version >= 2.11. Exiting successfully."
-                exit 0
+                echo "exit_early=true" >> $GITHUB_ENV
               else
                 echo "No Dockerfile.py3.* found. Exiting."
                 exit 1
@@ -156,6 +165,14 @@ jobs:
             fi
           else
             echo "DOCKERFILE=${{ env.DOCKERFILE }}" >> $GITHUB_ENV
+          fi
+
+      - name: Check if should exit early
+        id: check_exit_early
+        run: |
+          if [[ "${{ env.exit_early }}" == "true" ]]; then
+            echo "Exiting early."
+            exit 0
           fi
 
       - name: Generate suffix tag
@@ -195,6 +212,7 @@ jobs:
     name: Build and push test image from dev
     runs-on: ubuntu-latest
     needs: [build_and_push_base, build_and_push_dev]
+    if: needs.build_and_push_base.outputs.exit_early != 'true' && needs.build_and_push_dev.outputs.exit_early != 'true'
     env:
       CKAN_VERSION: ${{ needs.build_and_push_base.outputs.ckan_version }}
       DOCKER_LABELS: ${{ needs.build_and_push_base.outputs.docker_labels }}
@@ -226,5 +244,5 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           # Test only use base Dockerfile
-          dockerfile: ${{ env.CONTEXT }}/${{ env.BRANCH }}/test/Dockerfile
+          dockerfile: ${{ env.CONTEXT }}/${{ env.BRANCH }}/test/Dockerfile }}
           no-fail: true


### PR DESCRIPTION
- Added a step to log in to the Docker registry using the docker/login-action@v3.
- Added a step to build and push the test Docker image using the docker/build-push-action@v6.
  - The image is tagged with the registry, image name, and CKAN version.
  - Labels and annotations are added to the image.
  - The context and Dockerfile path are specified for the test image.
- Added a step to lint the test Dockerfile using hadolint/hadolint-action@v3.1.0.
  - The linting step is configured to not fail the workflow if issues are found.